### PR TITLE
fix: relogin after error500, refactor: remove console.logs

### DIFF
--- a/src/components/AllCards.tsx
+++ b/src/components/AllCards.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../hooks/redux';
 import { getAllCards } from '../redux/ac/card.ac';
+import { resetCardsError } from '../redux/slices/cardSlice';
 import { deleteUserSlice } from '../redux/slices/userSlice';
 import CardHeader from './Cards/CardHeader';
 import CardItem from './Cards/CardItem';
@@ -18,6 +19,7 @@ function AllCards() {
   if (error) {
     dispatch(deleteUserSlice());
     navigate('/logout');
+    dispatch(resetCardsError());
   }
 
   const renderedCards = cards.map((card) => (

--- a/src/components/Cards/Card.tsx
+++ b/src/components/Cards/Card.tsx
@@ -75,7 +75,6 @@ function Card() {
       if (!error) await dispatch(getColumns(params.id!));
       if (error) {
         dispatch(setColumns(initialColumns));
-        console.log('error from cards', error);
         Toast.fire({
           icon: 'error',
           title: 'Сolumns reorder error',

--- a/src/redux/ac/card.ac.ts
+++ b/src/redux/ac/card.ac.ts
@@ -11,7 +11,6 @@ const getAllCards = createAsyncThunk(
         credentials: 'include',
       });
       if (res.ok) {
-        console.log(res);
         const result = await res.json();
         return result;
       }

--- a/src/redux/ac/column.ac.ts
+++ b/src/redux/ac/column.ac.ts
@@ -29,11 +29,6 @@ const getColumns = createAsyncThunk(
       });
       if (res.ok) {
         const cols: IColumnAPI = await res.json();
-        // const colsWithTasks = await Promise.all(
-        //   // eslint-disable-next-line @typescript-eslint/return-await
-        //   cols.Columns.map(async (column) => (await getColumnById(column.id))),
-        // );
-        // cols.Columns = colsWithTasks;
         return cols;
       }
       throw new TypeError('error loading columns');
@@ -116,8 +111,6 @@ const setColumnsOrder = createAsyncThunk(
   'columns/setOrder',
   async (payload: ISwap[], thunkAPI) => {
     try {
-      console.log(payload);
-      console.log(JSON.stringify(payload));
       const res = await fetch(endPoints.setColumnsOrder(), {
         method: 'PUT',
         headers: {
@@ -126,16 +119,8 @@ const setColumnsOrder = createAsyncThunk(
         credentials: 'include',
         body: JSON.stringify(payload),
       });
-      // if (res.ok) {
-        //   const result = await res.json();
-      //   // await Swal.fire(result);
-      //   console.log('Поменяли', payload, result);
-      //   return result;
-      // }
       return res.statusText;
-      // throw new Error('Ошибка при реордере');
     } catch (error) {
-      console.log('какой-то еррор', error);
       return thunkAPI.rejectWithValue(error);
     }
   },

--- a/src/redux/ac/tasks.ac.ts
+++ b/src/redux/ac/tasks.ac.ts
@@ -13,9 +13,7 @@ const getColumnTasks = createAsyncThunk(
         credentials: 'include',
       });
       if (res.ok) {
-        console.log('таски', res);
         const result: IColumnTasks = await res.json();
-        console.log('айййй доля воровская', result);
         return { col: payload, response: result };
       }
       throw new TypeError('Tasks loading error');
@@ -42,7 +40,6 @@ const createTask = createAsyncThunk(
       });
       if (res.ok) {
         const result: ITask = await res.json();
-        console.log('СОЗДАЕМ', result);
         return result;
       }
       throw new TypeError('Task creating error');

--- a/src/redux/slices/cardSlice.ts
+++ b/src/redux/slices/cardSlice.ts
@@ -13,7 +13,9 @@ const initialState: ICadsState = {
 const cardSlice = createSlice({
   name: 'card',
   initialState,
-  reducers: {},
+  reducers: {
+    resetCardsError: (state) => { state.error = ''; },
+  },
   extraReducers: {
     [getAllCards.fulfilled.type]: (state, action: PayloadAction<ICardAPI[]>) => {
       state.isLoading = false;
@@ -85,3 +87,4 @@ const cardSlice = createSlice({
 });
 
 export default cardSlice.reducer;
+export const { resetCardsError } = cardSlice.actions;


### PR DESCRIPTION
If we are already loggin, but our token has expired, we will get a 500 error after any request.
After that, the user will automatically logout and be redirected to /login.
After a successful login, everything will be fine. Added user notification.